### PR TITLE
Internalize some structs / deprecate evhtp_set_hook()

### DIFF
--- a/evhtp.h
+++ b/evhtp.h
@@ -51,6 +51,8 @@ extern "C" {
 } while (0)
 #endif
 
+struct evhtp_callback_s;
+struct evhtp_callbacks_s;
 
 #ifndef EVHTP_DISABLE_SSL
 typedef SSL_SESSION               evhtp_ssl_sess_t;
@@ -337,39 +339,6 @@ struct evhtp_s {
     TAILQ_ENTRY(evhtp_s) next_vhost;
 };
 
-/**
- * @brief structure containing a single callback and configuration
- *
- * The definition structure which is used within the evhtp_callbacks_t
- * structure. This holds information about what should execute for either
- * a single or regex path.
- *
- * For example, if you registered a callback to be executed on a request
- * for "/herp/derp", your defined callback will be executed.
- *
- * Optionally you can set callback-specific hooks just like per-connection
- * hooks using the same rules.
- *
- */
-struct evhtp_callback_s {
-    evhtp_callback_type type;           /**< the type of callback (regex|path) */
-    evhtp_callback_cb   cb;             /**< the actual callback function */
-    unsigned int        hash;           /**< the full hash generated integer */
-    void              * cbarg;          /**< user-defind arguments passed to the cb */
-    evhtp_hooks_t     * hooks;          /**< per-callback hooks */
-
-    union {
-        char * path;
-        char * glob;
-#ifndef EVHTP_DISABLE_REGEX
-        regex_t * regex;
-#endif
-    } val;
-
-    TAILQ_ENTRY(evhtp_callback_s) next;
-};
-
-TAILQ_HEAD(evhtp_callbacks_s, evhtp_callback_s);
 
 /**
  * @brief a generic key/value structure
@@ -796,9 +765,12 @@ EVHTP_EXPORT evhtp_callback_t * evhtp_get_cb(evhtp_t * htp, const char * needle)
  *
  * @return 0 on success, -1 on error (if hooks is NULL, it is allocated)
  */
-EVHTP_EXPORT int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type,
-    evhtp_hook cb, void * arg);
+EVHTP_EXPORT int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
+DEPRECATED("use evhtp_[connection|request|callback]_set_hook() instead of set_hook directly");
 
+EVHTP_EXPORT int evhtp_connection_set_hook(evhtp_connection_t * c, evhtp_hook_type type, evhtp_hook cb, void * arg);
+EVHTP_EXPORT int evhtp_request_set_hook(evhtp_request_t * r, evhtp_hook_type type, evhtp_hook cb, void * arg);
+EVHTP_EXPORT int evhtp_callback_set_hook(evhtp_callback_t * cb, evhtp_hook_type type, evhtp_hook hookcb, void * arg);
 
 /**
  * @brief remove a specific hook from being called.

--- a/evhtp_json.c
+++ b/evhtp_json.c
@@ -10,7 +10,6 @@
 #include <ctype.h>
 #include <unistd.h>
 
-#include "internal.h"
 
 #include "evhtp_heap.h"
 #include "evhtp_json.h"


### PR DESCRIPTION
#10
 Let this burn in until the all-clear is given by users.

- Created the following functions which replace `evhtp_set_hook()`
  * evhtp_connection_set_hook()
  * evhtp_request_set_hook()
  * evhtp_callback_set_hook()

  These have the same params as set_hook aside from the specific data
  type.

  This is part of the effort of un-exposing all of the (internal)
  structures.