### PR TITLE
Fix typo in `evthr_new()` function name

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -242,7 +242,7 @@ _evthr_new(evthr_init_cb init_cb, evthr_exit_cb exit_cb, void * args) {
 } /* evthr_new */
 
 evthr_t *
-evhtr_new(evthr_init_cb init_cb, void * args) {
+evthr_new(evthr_init_cb init_cb, void * args) {
     return _evthr_new(init_cb, NULL, args);
 }
 


### PR DESCRIPTION
This regression was introduced in b6340022fcec.