### PR TITLE
Fix compilation with shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ add_library           (evhtp ${EVHTP_LIBTYPE} ${LIBEVHTP_SOURCE_FILES})
 target_link_libraries (evhtp ${LIBEVHTP_EXTERNAL_LIBS})
 
 if (EVHTP_BUILD_SHARED)
-        set_target_properties(evhtp PROPERTIES VERSION "${PROJECT_VERSION}" 0 OUTPUT_NAME "evhtp")
+        set_target_properties(evhtp PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION 0 OUTPUT_NAME "evhtp")
 endif()
 
 add_subdirectory(examples)


### PR DESCRIPTION
`set_target_properties` is missing an argument name for setting
SOVERSION, resulting in a build error when configuring:

```
CMake Error at CMakeLists.txt:199 (set_target_properties):
  set_target_properties called with incorrect number of arguments.
```