### PR TITLE
New SSL Utility API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,8 @@ set(LIBEVHTP_EXTERNAL_LIBS
 set (LIBEVHTP_SOURCE_FILES
     evhtp.c
     numtoa.c
-    parser.c)
+    parser.c
+    sslutils.c)
 
 if (NOT EVHTP_DISABLE_EVTHR)
     list (APPEND LIBEVHTP_SOURCE_FILES  thread.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,8 +185,11 @@ set(LIBEVHTP_EXTERNAL_LIBS
 set (LIBEVHTP_SOURCE_FILES
     evhtp.c
     numtoa.c
-    parser.c
-    sslutils.c)
+    parser.c)
+
+if (NOT EVHTP_DISABLE_SSL)
+    list (APPEND LIBEVHTP_SOURCE_FILES sslutils.c)
+endif()
 
 if (NOT EVHTP_DISABLE_EVTHR)
     list (APPEND LIBEVHTP_SOURCE_FILES  thread.c)
@@ -225,6 +228,14 @@ install (
         ${PROJECT_SOURCE_DIR}/include/evhtp.h
     DESTINATION
         ${INCLUDE_INSTALL_DIR})
+
+if (NOT EVHTP_DISABLE_SSL)
+    install (
+        FILES
+            ${PROJECT_SOURCE_DIR}/include/evhtp/sslutils.h
+        DESTINATION
+            ${INCLUDE_INSTALL_DIR}/evhtp)
+endif()
 
 if (NOT EVHTP_DISABLE_EVTHR)
     install (

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -11,9 +11,11 @@ option (EVHTP_DISABLE_REGEX "Disable regex support"        OFF)
 option (EVHTP_BUILD_SHARED  "Build shared library too"     OFF)
 
 # -DEVHTP_DEBUG:STRING=ON
-option (EVHTP_DEBUG         "Enable verbose debug logging" OFF)
+option (EVHTP_DEBUG         "Enable verbose debug logging"     OFF)
 
 # can be overwritten by new set_alloc functions
-option (EVHTP_USE_JEMALLOC  "Enable jemalloc allocator"    OFF)
-option (EVHTP_USE_TCMALLOC  "Enable tcmalloc allocator"    OFF)
+option (EVHTP_USE_JEMALLOC  "Enable jemalloc allocator"        OFF)
+option (EVHTP_USE_TCMALLOC  "Enable tcmalloc allocator"        OFF)
 
+# disable ability to wrap memory functions
+option (EVHTP_DISABLE_MEMFUNCTIONS "Disable custom allocators" OFF)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(test_query EXCLUDE_FROM_ALL test_query.c)
 add_executable(test_perf EXCLUDE_FROM_ALL test_perf.c)
 add_executable(example_vhost EXCLUDE_FROM_ALL example_vhost.c)
 add_executable(example_pause EXCLUDE_FROM_ALL example_pause.c)
-add_executable(example_https EXCLUDE_FROM_ALL https/example_https.c)
+
 
 if (NOT EVHTP_DISABLE_EVTHR)
 	add_executable(test_proxy EXCLUDE_FROM_ALL test_proxy.c)
@@ -24,16 +24,22 @@ target_link_libraries(test_query   evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 target_link_libraries(test_perf    evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 target_link_libraries(example_vhost evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 target_link_libraries(example_pause evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
-target_link_libraries(example_https evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 
-add_dependencies(examples example_https example_pause example_vhost test_extensive test_basic test_vhost test_client test_query test_perf)
 
-file (COPY
-    https/etc/ca.cnf
-    https/etc/client1.cnf
-    https/etc/client2.cnf
-    https/etc/server.cnf
-    DESTINATION
-    https/etc/)
+if (NOT EVHTP_DISABLE_SSL)
+    file (COPY
+        https/etc/ca.cnf
+        https/etc/client1.cnf
+        https/etc/client2.cnf
+        https/etc/server.cnf
+        DESTINATION https/etc/)
 
-configure_file(https/bin/generate.sh.in https/bin/generate.sh @ONLY)
+    configure_file(https/bin/generate.sh.in https/bin/generate.sh @ONLY)
+
+    add_executable(example_https EXCLUDE_FROM_ALL https/example_https.c)
+    target_link_libraries(example_https evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
+
+    add_dependencies(examples example_https)
+endif()
+
+add_dependencies(examples example_pause example_vhost test_extensive test_basic test_vhost test_client test_query test_perf)

--- a/examples/https/README.md
+++ b/examples/https/README.md
@@ -29,4 +29,54 @@ curl -kv \
   --key  examples/https/client1-key.pem \
   --cert examples/https/client1-crt.pem \
   https://localhost:4443/
+
+```
+
+The output (with client-certs) should look like:
+
+```
+< HTTP/1.1 200 OK
+< X-SSL-Subject: /C=US/ST=MA/L=Boston/O=Critical Stack/OU=evhtp/CN=client1/emailAddress=nate@cl0d.com
+< X-SSL-Issuer: /C=US/ST=MA/L=Boston/O=Critical Stack/OU=evhtp/CN=ca/emailAddress=nate@cl0d.com
+< X-SSL-Notbefore: Dec  7 16:10:34 2017 GMT
+< X-SSL-Notafter: Sep  1 16:10:34 2020 GMT
+< X-SSL-Serial: 57459A54BD08848C6D1546C2733EAD8A03553670
+< X-SSL-Cipher: ECDHE-RSA-AES256-GCM-SHA384
+< X-SSL-Sha1: 7A:68:47:CD:79:18:FF:DA:65:BC:67:6B:C2:5D:F3:66:9A:4A:64:7A
+< X-SSL-Certificate: -----BEGIN CERTIFICATE-----
+< 	MIIFkDCCA3igAwIBAgIUV0WaVL0IhIxtFUbCcz6tigNVNnAwDQYJKoZIhvcNAQEL
+< 	BQAwfzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk1BMQ8wDQYDVQQHDAZCb3N0b24x
+< 	FzAVBgNVBAoMDkNyaXRpY2FsIFN0YWNrMQ4wDAYDVQQLDAVldmh0cDELMAkGA1UE
+< 	AwwCY2ExHDAaBgkqhkiG9w0BCQEWDW5hdGVAY2wwZC5jb20wHhcNMTcxMjA3MTYx
+< 	MDM0WhcNMjAwOTAxMTYxMDM0WjCBhDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk1B
+< 	MQ8wDQYDVQQHDAZCb3N0b24xFzAVBgNVBAoMDkNyaXRpY2FsIFN0YWNrMQ4wDAYD
+< 	VQQLDAVldmh0cDEQMA4GA1UEAwwHY2xpZW50MTEcMBoGCSqGSIb3DQEJARYNbmF0
+< 	ZUBjbDBkLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALVoTyUm
+< 	62PqJ9RHkNewV+0Dn6AvTVYXQRIejORB75e1OklAp3LGw+Nlc1iP5/MjKzTtMpxk
+< 	kLDTDDhiX1mC2j9BDYOC6gpWEVosyU+fXaQvCxWKy4BASPUk7toLwgHxv855TTjV
+< 	2pe6VtAsImCT6sUGrKDnywAFvsBriXnzbTllm4gl7oPi8TrVZhk475JjEKgGKzsS
+< 	wtpbxNUqiTXe5lQ/jU6oCCMWG1VWgPLLTIZElhp/TPqLO976DutPXuCBy56NoPMy
+< 	DRm7YarhmG1vQNFdeJmC8/xdnKCbQpVhR9sF13tNIc+9QlTKNwzn375MK9e+xjXO
+< 	nc8RuqRLeJcMrs5bx5Mtd28F+yNA0riGGtp72vse95bG0PoVUhAqzog4iceHtt6M
+< 	4jyyBhICHYKhkrAYoy3lQdfckiiu5GjZ4rPAq+PP4XPgcXYeqxph6OA+IJwUcWjK
+< 	KjfQHvKJbIfo1ILQ4wzGxJ2KAE7F8CBrgokhYmshOMpDx6C4RPwifbtN2GcJN3Vc
+< 	kaKGwE72PExFcCLKXwJvXTz+4P87JywCCtYXbUXlgn6rMe4JSRn1NZF00nkeV5bD
+< 	AwCCoqSR5Qg9VUyhZKMF3zyQjHKS07SRDyl2vKLFUxnIu+6y4FxvnQqQOdDoz0BG
+< 	Uf/s2KNRWK3w3i7hDz0mAQpXyeqmGilT4NZhAgMBAAEwDQYJKoZIhvcNAQELBQAD
+< 	ggIBAIypf+0b+5xDRZ4IkcnlbUemZ0xt14UIw4N1Dr2kqp94gu4Z1nkLvYpLg61W
+< 	sy3vJLDKc1kSPZG5sPEj/W9zophaSQzL8P/yLHQ3psk2+ie/XDmpmvMsvsVExgut
+< 	lOExwMVfp+dIJ1cVfK5i8oMIE0IBbtdAIE/tzV+zzHpvAdA9KDcydW4oF+FLRLmQ
+< 	+qfKnK1BkxWqQayNmsbVN63ao8i/4OKD5VtKGPC5RdsEURIDc579lFKACpUnQGaJ
+< 	EKX/dKNiqoJSqOEDSsCN6jSJ7uTr5do+7xydqOcTQ+gI3FQsC1NjseqRRU0Q4HVL
+< 	95crEmqxlOxOjcrQK6U36HyKfn7EJ1B6/SJM8U9abOKBRUQjgLlrC6GaA/rToHmX
+< 	mlkqw2nKTnZhvIGmi0UjwtOD8rQnGahnq+jwoQV6Ag2YbSfeygvajJvdLBjEBYm+
+< 	5F6nQgv3JR9iJoS9AxcCEURH7jIAfdbYT6RBT3VARZyPcPtLSMFLLcXh0Z/Egifi
+< 	f+xTIL7mCgdW2Jp5s8cNjhrWk6dJVaXwwA6MNSfDeWeu7uHRm3Ir0Jwoe5I2pENm
+< 	mKueI6EhIKc6tdQWS6t+ZM0IJsVvhh4s0FqeUFYCP7RxG+P4u5wZxHdjbfUUJ8zA
+< 	xHMrDvO8p6dwRUDAPkOqCPpdGmBky/ukBXNi2u0OOJ+wUgoA
+< 	-----END CERTIFICATE-----
+< Content-Length: 0
+< Content-Type: text/plain
+<
+
 ```

--- a/examples/https/example_https.c
+++ b/examples/https/example_https.c
@@ -13,8 +13,88 @@
 #include "evhtp/evhtp.h"
 
 #ifndef EVHTP_DISABLE_SSL
+#include "evhtp/sslutils.h"
+
+static void
+ssl__add_x_headers_(evhtp_headers_t * headers, evhtp_ssl_t * ssl) {
+    unsigned char * subj_str = NULL;
+    unsigned char * issr_str = NULL;
+    unsigned char * nbf_str  = NULL;
+    unsigned char * naf_str  = NULL;
+    unsigned char * ser_str  = NULL;
+    unsigned char * cip_str  = NULL;
+    unsigned char * sha1_str = NULL;
+    unsigned char * cert_str = NULL;
+
+    if ((subj_str = htp_sslutil_subject_tostr(ssl))) {
+        evhtp_headers_add_header(
+            headers,
+            evhtp_header_new("X-SSL-Subject", subj_str, 0, 1));
+    }
+
+    if ((issr_str = htp_sslutil_issuer_tostr(ssl))) {
+        evhtp_headers_add_header(
+            headers,
+            evhtp_header_new("X-SSL-Issuer", issr_str, 0, 1));
+    }
+
+    if ((nbf_str = htp_sslutil_notbefore_tostr(ssl))) {
+        evhtp_headers_add_header(
+            headers,
+            evhtp_header_new("X-SSL-Notbefore", nbf_str, 0, 1));
+    }
+
+    if ((naf_str = htp_sslutil_notafter_tostr(ssl))) {
+        evhtp_headers_add_header(
+            headers,
+            evhtp_header_new("X-SSL-Notafter", naf_str, 0, 1));
+    }
+
+    if ((ser_str = htp_sslutil_serial_tostr(ssl))) {
+        evhtp_headers_add_header(
+            headers,
+            evhtp_header_new("X-SSL-Serial", ser_str, 0, 1));
+    }
+
+    if ((cip_str = htp_sslutil_cipher_tostr(ssl))) {
+        evhtp_headers_add_header(
+            headers,
+            evhtp_header_new("X-SSL-Cipher", cip_str, 0, 1));
+    }
+
+    if ((sha1_str = htp_sslutil_sha1_tostr(ssl))) {
+        evhtp_headers_add_header(
+            headers,
+            evhtp_header_new("X-SSL-Sha1", sha1_str, 0, 1));
+    }
+
+    if ((cert_str = htp_sslutil_cert_tostr(ssl))) {
+        evhtp_headers_add_header(
+            headers,
+            evhtp_header_new("X-SSL-Certificate", cert_str, 0, 1));
+    }
+
+    free(subj_str);
+    free(issr_str);
+    free(nbf_str);
+    free(naf_str);
+    free(ser_str);
+    free(cip_str);
+    free(sha1_str);
+    free(cert_str);
+} /* ssl__add_x_headers_ */
+
 static void
 http__callback_(evhtp_request_t * req, void * arg) {
+    evhtp_connection_t * conn;
+
+    evhtp_assert(req != NULL);
+
+    conn = evhtp_request_get_connection(req);
+    evhtp_assert(conn != NULL);
+
+    ssl__add_x_headers_(req->headers_out, conn->ssl);
+
     return evhtp_send_reply(req, EVHTP_RES_OK);
 }
 
@@ -135,7 +215,7 @@ parse__ssl_opts_(int argc, char ** argv) {
                 ssl_config->ciphers         = strdup(optarg);
                 break;
             case OPTARG_VERIFY_DEPTH:
-                ssl_config->verify_depth = atoi(optarg);
+                ssl_config->verify_depth    = atoi(optarg);
                 break;
             case OPTARG_VERIFY_PEER:
                 ssl_verify_mode            |= SSL_VERIFY_PEER;
@@ -220,6 +300,7 @@ parse__ssl_opts_(int argc, char ** argv) {
 
     return ssl_config;
 } /* parse__ssl_opts_ */
+
 #endif
 
 int

--- a/include/evhtp/config.h.in
+++ b/include/evhtp/config.h.in
@@ -42,6 +42,7 @@ extern "C" {
 #cmakedefine EVHTP_USE_JEMALLOC
 #cmakedefine EVHTP_USE_TCMALLOC
 #cmakedefine EVHTP_DEBUG
+#cmakedefine EVHTP_DISABLE_MEMFUNCTIONS
 
 #ifndef EVHTP_DISABLE_REGEX
 #include <onigposix.h>

--- a/include/evhtp/sslutils.h
+++ b/include/evhtp/sslutils.h
@@ -1,0 +1,30 @@
+/**
+ * @file sslutils.h
+ */
+
+#ifndef __EVHTP_SSLUTILS_H__
+#define __EVHTP_SSLUTILS_H__
+
+#include <evhtp/config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+EVHTP_EXPORT unsigned char * htp_sslutil_subject_tostr(evhtp_ssl_t * ssl);
+EVHTP_EXPORT unsigned char * htp_sslutil_issuer_tostr(evhtp_ssl_t * ssl);
+EVHTP_EXPORT unsigned char * htp_sslutil_notbefore_tostr(evhtp_ssl_t * ssl);
+EVHTP_EXPORT unsigned char * htp_sslutil_notafter_tostr(evhtp_ssl_t * ssl);
+EVHTP_EXPORT unsigned char * htp_sslutil_sha1_tostr(evhtp_ssl_t * ssl);
+EVHTP_EXPORT unsigned char * htp_sslutil_serial_tostr(evhtp_ssl_t * ssl);
+EVHTP_EXPORT unsigned char * htp_sslutil_cipher_tostr(evhtp_ssl_t * ssl);
+EVHTP_EXPORT unsigned char * htp_sslutil_cert_tostr(evhtp_ssl_t * ssl);
+EVHTP_EXPORT unsigned char * htp_sslutil_x509_ext_tostr(evhtp_ssl_t * ssl, const char * oid);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/sslutils.c
+++ b/sslutils.c
@@ -7,11 +7,11 @@
 
 #include "evhtp/config.h"
 #include "evhtp/evhtp.h"
+#include "evhtp/sslutils.h"
 #include "internal.h"
 
 unsigned char *
 htp_sslutil_subject_tostr(evhtp_ssl_t * ssl) {
-#ifndef EVHTP_DISABLE_SSL
     unsigned char * subj_str;
     char          * p;
     X509          * cert;
@@ -41,14 +41,10 @@ htp_sslutil_subject_tostr(evhtp_ssl_t * ssl) {
     X509_free(cert);
 
     return subj_str;
-#else
-    return NULL;
-#endif
 }
 
 unsigned char *
 htp_sslutil_issuer_tostr(evhtp_ssl_t * ssl) {
-#ifndef EVHTP_DISABLE_SSL
     X509          * cert;
     X509_NAME     * name;
     char          * p;
@@ -78,14 +74,10 @@ htp_sslutil_issuer_tostr(evhtp_ssl_t * ssl) {
     X509_free(cert);
 
     return issr_str;
-#else
-    return NULL;
-#endif
 }
 
 unsigned char *
 htp_sslutil_notbefore_tostr(evhtp_ssl_t * ssl) {
-#ifndef EVHTP_DISABLE_SSL
     BIO           * bio;
     X509          * cert;
     ASN1_TIME     * time;
@@ -132,14 +124,10 @@ htp_sslutil_notbefore_tostr(evhtp_ssl_t * ssl) {
     X509_free(cert);
 
     return time_str;
-#else
-    return NULL;
-#endif
 } /* htp_sslutil_notbefore_tostr */
 
 unsigned char *
 htp_sslutil_notafter_tostr(evhtp_ssl_t * ssl) {
-#ifndef EVHTP_DISABLE_SSL
     BIO           * bio;
     X509          * cert;
     ASN1_TIME     * time;
@@ -186,14 +174,10 @@ htp_sslutil_notafter_tostr(evhtp_ssl_t * ssl) {
     X509_free(cert);
 
     return time_str;
-#else
-    return NULL;
-#endif
 } /* htp_sslutil_notafter_tostr */
 
 unsigned char *
 htp_sslutil_sha1_tostr(evhtp_ssl_t * ssl) {
-#ifndef EVHTP_DISABLE_SSL
     const EVP_MD  * md_alg;
     X509          * cert;
     unsigned int    n;
@@ -242,14 +226,10 @@ htp_sslutil_sha1_tostr(evhtp_ssl_t * ssl) {
     X509_free(cert);
 
     return buf;
-#else
-    return NULL;
-#endif
 } /* htp_sslutil_sha1_tostr */
 
 unsigned char *
 htp_sslutil_serial_tostr(evhtp_ssl_t * ssl) {
-#ifndef EVHTP_DISABLE_SSL
     BIO           * bio;
     X509          * cert;
     size_t          len;
@@ -286,14 +266,10 @@ htp_sslutil_serial_tostr(evhtp_ssl_t * ssl) {
     BIO_free(bio);
 
     return ser_str;
-#else
-    return NULL;
-#endif
 } /* htp_sslutil_serial_tostr */
 
 unsigned char *
 htp_sslutil_cipher_tostr(evhtp_ssl_t * ssl) {
-#ifndef EVHTP_DISABLE_SSL
     const SSL_CIPHER * cipher;
     const char       * p;
     unsigned char    * cipher_str;
@@ -313,14 +289,10 @@ htp_sslutil_cipher_tostr(evhtp_ssl_t * ssl) {
     cipher_str = strdup(p);
 
     return cipher_str;
-#else
-    return NULL;
-#endif
 }
 
 unsigned char *
 htp_sslutil_cert_tostr(evhtp_ssl_t * ssl) {
-#ifndef EVHTP_DISABLE_SSL
     X509          * cert;
     BIO           * bio;
     unsigned char * raw_cert_str;
@@ -391,14 +363,10 @@ htp_sslutil_cert_tostr(evhtp_ssl_t * ssl) {
     free(raw_cert_str);
 
     return cert_str;
-#else
-    return NULL;
-#endif
 } /* htp_sslutil_cert_tostr */
 
 unsigned char *
 htp_sslutil_x509_ext_tostr(evhtp_ssl_t * ssl, const char * oid) {
-#ifndef EVHTP_DISABLE_SSL
     unsigned char       * ext_str;
     X509                * cert;
     ASN1_OBJECT         * oid_obj;
@@ -457,7 +425,4 @@ htp_sslutil_x509_ext_tostr(evhtp_ssl_t * ssl, const char * oid) {
     X509_free(cert);
 
     return ext_str;
-#else
-    return NULL;
-#endif
 } /* htp_sslutil_x509_ext_tostr */

--- a/sslutils.c
+++ b/sslutils.c
@@ -1,0 +1,463 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "evhtp/config.h"
+#include "evhtp/evhtp.h"
+#include "internal.h"
+
+unsigned char *
+htp_sslutil_subject_tostr(evhtp_ssl_t * ssl) {
+#ifndef EVHTP_DISABLE_SSL
+    unsigned char * subj_str;
+    char          * p;
+    X509          * cert;
+    X509_NAME     * name;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    if (!(cert = SSL_get_peer_certificate(ssl))) {
+        return NULL;
+    }
+
+    if (!(name = X509_get_subject_name(cert))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!(p = X509_NAME_oneline(name, NULL, 0))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    subj_str = strdup(p);
+
+    OPENSSL_free(p);
+    X509_free(cert);
+
+    return subj_str;
+#else
+    return NULL;
+#endif
+}
+
+unsigned char *
+htp_sslutil_issuer_tostr(evhtp_ssl_t * ssl) {
+#ifndef EVHTP_DISABLE_SSL
+    X509          * cert;
+    X509_NAME     * name;
+    char          * p;
+    unsigned char * issr_str;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    if (!(cert = SSL_get_peer_certificate(ssl))) {
+        return NULL;
+    }
+
+    if (!(name = X509_get_issuer_name(cert))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!(p = X509_NAME_oneline(name, NULL, 0))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    issr_str = strdup(p);
+
+    OPENSSL_free(p);
+    X509_free(cert);
+
+    return issr_str;
+#else
+    return NULL;
+#endif
+}
+
+unsigned char *
+htp_sslutil_notbefore_tostr(evhtp_ssl_t * ssl) {
+#ifndef EVHTP_DISABLE_SSL
+    BIO           * bio;
+    X509          * cert;
+    ASN1_TIME     * time;
+    size_t          len;
+    unsigned char * time_str;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    if (!(cert = SSL_get_peer_certificate(ssl))) {
+        return NULL;
+    }
+
+    if (!(time = X509_get_notBefore(cert))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!(bio = BIO_new(BIO_s_mem()))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!ASN1_TIME_print(bio, time)) {
+        BIO_free(bio);
+        X509_free(cert);
+        return NULL;
+    }
+
+    if ((len = BIO_pending(bio)) == 0) {
+        BIO_free(bio);
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!(time_str = calloc(len + 1, 1))) {
+        return NULL;
+    }
+
+    BIO_read(bio, time_str, len);
+
+    BIO_free(bio);
+    X509_free(cert);
+
+    return time_str;
+#else
+    return NULL;
+#endif
+} /* htp_sslutil_notbefore_tostr */
+
+unsigned char *
+htp_sslutil_notafter_tostr(evhtp_ssl_t * ssl) {
+#ifndef EVHTP_DISABLE_SSL
+    BIO           * bio;
+    X509          * cert;
+    ASN1_TIME     * time;
+    size_t          len;
+    unsigned char * time_str;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    if (!(cert = SSL_get_peer_certificate(ssl))) {
+        return NULL;
+    }
+
+    if (!(time = X509_get_notAfter(cert))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!(bio = BIO_new(BIO_s_mem()))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!ASN1_TIME_print(bio, time)) {
+        BIO_free(bio);
+        X509_free(cert);
+        return NULL;
+    }
+
+    if ((len = BIO_pending(bio)) == 0) {
+        BIO_free(bio);
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!(time_str = calloc(len + 1, 1))) {
+        return NULL;
+    }
+
+    BIO_read(bio, time_str, len);
+
+    BIO_free(bio);
+    X509_free(cert);
+
+    return time_str;
+#else
+    return NULL;
+#endif
+} /* htp_sslutil_notafter_tostr */
+
+unsigned char *
+htp_sslutil_sha1_tostr(evhtp_ssl_t * ssl) {
+#ifndef EVHTP_DISABLE_SSL
+    const EVP_MD  * md_alg;
+    X509          * cert;
+    unsigned int    n;
+    unsigned char   md[EVP_MAX_MD_SIZE];
+    unsigned char * buf = NULL;
+    size_t          offset;
+    size_t          nsz;
+    int             sz;
+    int             i;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    md_alg = EVP_sha1();
+
+    if (!md_alg) {
+        return NULL;
+    }
+
+    if (!(cert = SSL_get_peer_certificate(ssl))) {
+        return NULL;
+    }
+
+    n   = 0;
+    if (!X509_digest(cert, md_alg, md, &n)) {
+        return NULL;
+    }
+
+    nsz = 3 * n + 1;
+    buf = (unsigned char *)calloc(nsz, 1);
+    if (buf) {
+        offset = 0;
+        for (i = 0; i < n; i++) {
+            sz      = snprintf(buf + offset, nsz - offset, "%02X%c", md[i], (i + 1 == n) ? 0 : ':');
+            offset += sz;
+
+            if (sz < 0 || offset >= nsz) {
+                free(buf);
+                buf = NULL;
+                break;
+            }
+        }
+    }
+
+    X509_free(cert);
+
+    return buf;
+#else
+    return NULL;
+#endif
+} /* htp_sslutil_sha1_tostr */
+
+unsigned char *
+htp_sslutil_serial_tostr(evhtp_ssl_t * ssl) {
+#ifndef EVHTP_DISABLE_SSL
+    BIO           * bio;
+    X509          * cert;
+    size_t          len;
+    unsigned char * ser_str;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    if (!(cert = SSL_get_peer_certificate(ssl))) {
+        return NULL;
+    }
+
+    if (!(bio = BIO_new(BIO_s_mem()))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    i2a_ASN1_INTEGER(bio, X509_get_serialNumber(cert));
+
+    if ((len = BIO_pending(bio)) == 0) {
+        BIO_free(bio);
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!(ser_str = calloc(len + 1, 1))) {
+        return NULL;
+    }
+
+    BIO_read(bio, ser_str, len);
+
+    X509_free(cert);
+    BIO_free(bio);
+
+    return ser_str;
+#else
+    return NULL;
+#endif
+} /* htp_sslutil_serial_tostr */
+
+unsigned char *
+htp_sslutil_cipher_tostr(evhtp_ssl_t * ssl) {
+#ifndef EVHTP_DISABLE_SSL
+    const SSL_CIPHER * cipher;
+    const char       * p;
+    unsigned char    * cipher_str;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    if (!(cipher = SSL_get_current_cipher(ssl))) {
+        return NULL;
+    }
+
+    if (!(p = SSL_CIPHER_get_name(cipher))) {
+        return NULL;
+    }
+
+    cipher_str = strdup(p);
+
+    return cipher_str;
+#else
+    return NULL;
+#endif
+}
+
+unsigned char *
+htp_sslutil_cert_tostr(evhtp_ssl_t * ssl) {
+#ifndef EVHTP_DISABLE_SSL
+    X509          * cert;
+    BIO           * bio;
+    unsigned char * raw_cert_str;
+    unsigned char * cert_str;
+    unsigned char * p;
+    size_t          raw_cert_len;
+    size_t          cert_len;
+    int             i;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    if (!(cert = SSL_get_peer_certificate(ssl))) {
+        return NULL;
+    }
+
+    if (!(bio = BIO_new(BIO_s_mem()))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!PEM_write_bio_X509(bio, cert)) {
+        BIO_free(bio);
+        X509_free(cert);
+
+        return NULL;
+    }
+
+    raw_cert_len = BIO_pending(bio);
+    raw_cert_str = calloc(raw_cert_len + 1, 1);
+
+    BIO_read(bio, raw_cert_str, raw_cert_len);
+
+    cert_len     = raw_cert_len - 1;
+
+    for (i = 0; i < raw_cert_len - 1; i++) {
+        if (raw_cert_str[i] == '\n') {
+            /*
+             * \n's will be converted to \r\n\t, so we must reserve
+             * enough space for that much data.
+             */
+            cert_len += 2;
+        }
+    }
+
+    /* 2 extra chars, one for possible last char (if not '\n'), and one for NULL terminator */
+    cert_str = calloc(cert_len + 2, 1);
+    p        = cert_str;
+
+    for (i = 0; i < raw_cert_len - 1; i++) {
+        if (raw_cert_str[i] == '\n') {
+            *p++ = '\r';
+            *p++ = '\n';
+            *p++ = '\t';
+        } else {
+            *p++ = raw_cert_str[i];
+        }
+    }
+
+    /* Don't assume last character is '\n' */
+    if (raw_cert_str[i] != '\n') {
+        *p++ = raw_cert_str[i];
+    }
+
+    BIO_free(bio);
+    X509_free(cert);
+    free(raw_cert_str);
+
+    return cert_str;
+#else
+    return NULL;
+#endif
+} /* htp_sslutil_cert_tostr */
+
+unsigned char *
+htp_sslutil_x509_ext_tostr(evhtp_ssl_t * ssl, const char * oid) {
+#ifndef EVHTP_DISABLE_SSL
+    unsigned char       * ext_str;
+    X509                * cert;
+    ASN1_OBJECT         * oid_obj;
+    int                   oid_pos;
+    X509_EXTENSION      * ext;
+    ASN1_OCTET_STRING   * octet;
+    const unsigned char * octet_data;
+    long                  xlen;
+    int                   xtag;
+    int                   xclass;
+
+    if (!ssl) {
+        return NULL;
+    }
+
+    if (!(cert = SSL_get_peer_certificate(ssl))) {
+        return NULL;
+    }
+
+    if (!(oid_obj = OBJ_txt2obj(oid, 1))) {
+        X509_free(cert);
+        return NULL;
+    }
+
+    ext_str = NULL;
+    oid_pos = X509_get_ext_by_OBJ(cert, oid_obj, -1);
+
+    if (!(ext = X509_get_ext(cert, oid_pos))) {
+        ASN1_OBJECT_free(oid_obj);
+        X509_free(cert);
+        return NULL;
+    }
+
+    if (!(octet = X509_EXTENSION_get_data(ext))) {
+        ASN1_OBJECT_free(oid_obj);
+        X509_free(cert);
+        return NULL;
+    }
+
+    octet_data = octet->data;
+
+    if (ASN1_get_object(&octet_data, &xlen, &xtag, &xclass, octet->length)) {
+        ASN1_OBJECT_free(oid_obj);
+        X509_free(cert);
+        return NULL;
+    }
+
+    /* We're only supporting string data. Could optionally add support
+     * for encoded binary data */
+
+    if (xlen > 0 && xtag == 0x0C && octet->type == V_ASN1_OCTET_STRING) {
+        ext_str = strndup(octet_data, xlen);
+    }
+
+    ASN1_OBJECT_free(oid_obj);
+    X509_free(cert);
+
+    return ext_str;
+#else
+    return NULL;
+#endif
+} /* htp_sslutil_x509_ext_tostr */


### PR DESCRIPTION
The SSL utility API consists of various functions that make life easier when it comes to dealing with native SSL objects and converting them into other formats. A good example of this can be found in `examples/https/example_https.c` in the function `ssl__add_x_headers_()`

A quick run-down example, appending `X-` headers to the HTTP response for SSL'y type information:

```C
    unsigned char * subj_str = NULL;
    unsigned char * issr_str = NULL;
    unsigned char * nbf_str  = NULL;
    unsigned char * naf_str  = NULL;
    unsigned char * ser_str  = NULL;
    unsigned char * cip_str  = NULL;
    unsigned char * sha1_str = NULL;
    unsigned char * cert_str = NULL;
    
    if ((subj_str = htp_sslutil_subject_tostr(ssl))) {
        evhtp_headers_add_header(
            headers,
            evhtp_header_new("X-SSL-Subject", subj_str, 0, 1));
    }
    
    if ((issr_str = htp_sslutil_issuer_tostr(ssl))) {
        evhtp_headers_add_header(
            headers,
            evhtp_header_new("X-SSL-Issuer", issr_str, 0, 1));
    }
    
    if ((nbf_str = htp_sslutil_notbefore_tostr(ssl))) {
        evhtp_headers_add_header(
            headers,
            evhtp_header_new("X-SSL-Notbefore", nbf_str, 0, 1));
    }
    
    if ((naf_str = htp_sslutil_notafter_tostr(ssl))) {
        evhtp_headers_add_header(
            headers,
            evhtp_header_new("X-SSL-Notafter", naf_str, 0, 1));
    }
    
    if ((ser_str = htp_sslutil_serial_tostr(ssl))) {
        evhtp_headers_add_header(
            headers,
            evhtp_header_new("X-SSL-Serial", ser_str, 0, 1));
    }
    
    if ((cip_str = htp_sslutil_cipher_tostr(ssl))) {
        evhtp_headers_add_header(
            headers,
            evhtp_header_new("X-SSL-Cipher", cip_str, 0, 1));
    }
    
    if ((sha1_str = htp_sslutil_sha1_tostr(ssl))) {
        evhtp_headers_add_header(
            headers,
            evhtp_header_new("X-SSL-Sha1", sha1_str, 0, 1));
    }
    
    if ((cert_str = htp_sslutil_cert_tostr(ssl))) {
        evhtp_headers_add_header(
            headers,
            evhtp_header_new("X-SSL-Certificate", cert_str, 0, 1));
    }
    
    free(subj_str);
    free(issr_str);
    free(nbf_str);
    free(naf_str);
    free(ser_str);
    free(cip_str);
    free(sha1_str);
    free(cert_str);
```
