### PR TITLE
[#72] Fix for oob read from htparser_get_strerror

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -428,7 +428,7 @@ htparser_get_strerror(htparser * p)
 {
     htpparse_error e = htparser_get_error(p);
 
-    if (e > (htparse_error_generic + 1))
+    if (e > htparse_error_generic)
     {
         return "htparse_no_such_error";
     }


### PR DESCRIPTION
While the API was never effected by this, I guess a user who had set
their own parser error could have triggered this read. But alas, a bug
is a bug.

We don't look for error + 1 in the error string table, we just look for
error > last_enum.