### PR TITLE
[resolves #76] consistent member type definitions of struct evthr

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -45,7 +45,7 @@ struct evthr {
     pthread_mutex_t lock;
     pthread_t     * thr;
     evthr_init_cb   init_cb;
-    evthr_init_cb   exit_cb;
+    evthr_exit_cb   exit_cb;
     void          * arg;
     void          * aux;
 
@@ -189,7 +189,7 @@ evthr_set_initcb(evthr_t * thr, evthr_init_cb cb) {
 
     thr->init_cb = cb;
 
-    return 01;
+    return 0;
 }
 
 int
@@ -219,13 +219,13 @@ _evthr_new(evthr_init_cb init_cb, evthr_exit_cb exit_cb, void * args) {
         return NULL;
     }
 
-    thread->thr = malloc(sizeof(pthread_t));
-    thread->arg = args;
-    thread->rdr = fds[0];
-    thread->wdr = fds[1];
+    thread->thr     = malloc(sizeof(pthread_t));
+    thread->arg     = args;
+    thread->rdr     = fds[0];
+    thread->wdr     = fds[1];
 
-    evthr_set_initcb(thread, init_cb);
-    evthr_set_exitcb(thread, exit_cb);
+    thread->init_cb = init_cb;
+    thread->exit_cb = exit_cb;
 
     if (pthread_mutex_init(&thread->lock, NULL)) {
         evthr_free(thread);


### PR DESCRIPTION
The evthr struct references `exit_cb` of type `evthr_init_cb`.
The `evthr_init_cb` is a typedef to `void (*)(evthr_t *, void *)`

Both of these typedefs are of the same attributes, so nothing bad
happens here; it's more about readability. This patch simply changes
the value type definition of `exit_cb` to the aliased type
`evthr_exit_cb`.

Nothing changes, nothing was "broken", but we need to be consistent.