### PR TITLE
This patch "fixes" issue #90, sockopt refactor, and minor fixes.

### DIFF
--- a/evhtp.c
+++ b/evhtp.c
@@ -3228,11 +3228,11 @@ evhtp_kv_free(evhtp_kv_t * kv)
         return;
     }
 
-    if (kv->k_heaped) {
+    if (kv->k_heaped == 1) {
         evhtp_safe_free(kv->key, htp__free_);
     }
 
-    if (kv->v_heaped) {
+    if (kv->v_heaped == 1) {
         evhtp_safe_free(kv->val, htp__free_);
     }
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,13 +13,13 @@ add_executable(example_request_fini EXCLUDE_FROM_ALL example_request_fini.c)
 add_executable(example_basic EXCLUDE_FROM_ALL example_basic.c)
 
 if(NOT EVHTP_DISABLE_EVTHR)
-    add_executable(example_locality EXCLUDE_FROM_ALL example_locality.c)
-	target_link_libraries(example_locality evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
+    #add_executable(example_locality EXCLUDE_FROM_ALL example_locality.c)
+    #target_link_libraries(example_locality evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
    
 	add_executable(test_proxy EXCLUDE_FROM_ALL test_proxy.c)
 	target_link_libraries(test_proxy evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 
-	add_dependencies(examples test_proxy example_locality)
+	add_dependencies(examples test_proxy)
 endif()
 
 target_link_libraries(test_extensive evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,11 +10,16 @@ add_executable(example_vhost EXCLUDE_FROM_ALL example_vhost.c)
 add_executable(example_pause EXCLUDE_FROM_ALL example_pause.c)
 add_executable(example_chunked EXCLUDE_FROM_ALL example_chunked.c)
 add_executable(example_request_fini EXCLUDE_FROM_ALL example_request_fini.c)
+add_executable(example_basic EXCLUDE_FROM_ALL example_basic.c)
 
 if(NOT EVHTP_DISABLE_EVTHR)
+    add_executable(example_locality EXCLUDE_FROM_ALL example_locality.c)
+	target_link_libraries(example_locality evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
+   
 	add_executable(test_proxy EXCLUDE_FROM_ALL test_proxy.c)
 	target_link_libraries(test_proxy evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
-	add_dependencies(examples test_proxy)
+
+	add_dependencies(examples test_proxy example_locality)
 endif()
 
 target_link_libraries(test_extensive evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
@@ -27,6 +32,7 @@ target_link_libraries(example_vhost evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 target_link_libraries(example_pause evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 target_link_libraries(example_chunked evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 target_link_libraries(example_request_fini evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
+target_link_libraries(example_basic evhtp ${LIBEVHTP_EXTERNAL_LIBS} ${SYS_LIBS})
 
 if(NOT EVHTP_DISABLE_SSL)
     file(COPY
@@ -53,4 +59,4 @@ add_dependencies(examples
   example_vhost test_extensive
   test_basic
   test_vhost test_client
-  test_query test_perf)
+  test_query test_perf example_basic)

--- a/examples/eutils.h
+++ b/examples/eutils.h
@@ -4,7 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void * mm__dup_(const void * src, size_t size) {
+static void *
+mm__dup_(const void * src, size_t size)
+{
     void * mem = malloc(size);
 
     return mem ? memcpy(mem, src, size) : NULL;

--- a/examples/example_basic.c
+++ b/examples/example_basic.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <evhtp.h>
+#include <unistd.h>
+
+#include "../log.h"
+#include "./eutils.h"
+#include "internal.h"
+#include "evhtp/evhtp.h"
+
+static void
+process_request_(evhtp_request_t * req, void * arg)
+{
+    (void)arg;
+
+    evhtp_send_reply(req, EVHTP_RES_OK);
+}
+
+int
+main(int argc, char ** argv)
+{
+    (void)argc;
+    (void)argv;
+    struct event_base * evbase;
+    struct evhtp      * htp;
+
+    evbase = event_base_new();
+    htp    = evhtp_new(evbase, NULL);
+
+    evhtp_set_cb(htp, "/", process_request_, NULL);
+    evhtp_enable_flag(htp, EVHTP_FLAG_ENABLE_ALL);
+
+#ifndef EVHTP_DISABLE_EVTHR
+    /* create 1 listener, 4 acceptors */
+    evhtp_use_threads_wexit(htp, NULL, NULL, 4, NULL);
+#endif
+
+    log_info("Basic server, run: curl https://127.0.0.1:%d/",
+            bind__sock_port0_(htp));
+    event_base_loop(evbase, 0);
+    return 0;
+}

--- a/examples/example_locality.c
+++ b/examples/example_locality.c
@@ -1,0 +1,141 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include <pthread.h>
+#include <sched.h>
+#include <linux/bpf.h>
+#include <linux/filter.h>
+
+#include <evhtp/thread.h>
+#include <evhtp/evhtp.h>
+
+#define CPU__COUNT sysconf(_SC_NPROCESSORS_ONLN)
+
+static int _init    = 0;
+static int _threads = 0;
+
+struct cc__config {
+    char   * host;
+    uint16_t port;
+};
+
+static void
+dummy_eventcb_(int sock, short which, void * args)
+{
+    (void)sock;
+    (void)which;
+    (void)args;
+}
+
+static void
+process_request_(evhtp_request_t * req, void * arg)
+{
+    (void)arg;
+
+    evhtp_send_reply(req, EVHTP_RES_OK);
+}
+
+static void
+attach_cbpf_(int fd)
+{
+    struct sock_filter code[] = {
+        { BPF_LD | BPF_W | BPF_ABS, 0,          0, SKF_AD_OFF + SKF_AD_CPU }, /* A = raw_smp_processor_id() */
+        { BPF_RET | BPF_A,          0,          0, 0                       }, /* return A */
+    };
+
+    struct sock_fprog  p = {
+        .len    = 2,
+        .filter = code,
+    };
+
+    if (setsockopt(fd, SOL_SOCKET, SO_ATTACH_REUSEPORT_CBPF, &p,
+            sizeof(p)) == -1) {
+        fprintf(stderr, "failed to set SO_ATTACH_REUSEPORT_CBPF\n");
+    }
+}
+
+static void
+htp_worker_init_(evthr_t * thread, void * args)
+{
+    struct event_base * evbase;
+    struct cc__config * config;
+    struct evhtp      * htp;
+    int                 core;
+    cpu_set_t           cpu_set;
+
+    if (!(config = (struct cc__config *)args)) {
+    }
+
+    if (!(evbase = evthr_get_base(thread))) {
+        evthr_stop(thread);
+        return;
+    }
+
+    if (!(htp = evhtp_new(evbase, thread))) {
+        evthr_stop(thread);
+        return;
+    }
+
+    evhtp_set_cb(htp, "/", process_request_, thread);
+    evhtp_enable_flag(htp, EVHTP_FLAG_ENABLE_ALL);
+    /*evhtp_use_threads_wexit(htp, NULL, NULL, CPU__COUNT / 2, NULL); */
+
+    core = _threads++ % CPU__COUNT;
+    printf("me = %d\n", getppid());
+
+    CPU_ZERO(&cpu_set);
+    CPU_SET(core, &cpu_set);
+
+    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpu_set);
+
+    if (pthread_getaffinity_np(
+            pthread_self(),
+            sizeof(cpu_set_t), &cpu_set) == 0) {
+        int i;
+
+        for (i = 0; i < CPU__COUNT; i++) {
+            if (CPU_ISSET(i, &cpu_set)) {
+                printf("CPU %d\n", i);
+            }
+        }
+    }
+
+    evhtp_bind_socket(htp, "127.0.0.1", 8089, 1024);
+    attach_cbpf_(evconnlistener_get_fd(htp->server));
+} /* htp_worker_init_ */
+
+int
+main(int argc, char ** argv)
+{
+    (void)argc;
+    (void)argv;
+
+    struct event_base * evbase;
+    struct event      * dummy_ev;
+    evthr_pool_t      * workers;
+
+    evbase   = event_base_new();
+    dummy_ev = event_new(evbase, -1,
+        EV_READ | EV_PERSIST,
+        dummy_eventcb_, NULL);
+
+    event_add(dummy_ev, NULL);
+
+    if (!(workers =
+              evthr_pool_wexit_new(CPU__COUNT, htp_worker_init_, NULL, NULL))) {
+        exit(EXIT_FAILURE);
+    }
+
+    evthr_pool_start(workers);
+    event_base_loop(evbase, 0);
+
+    return 0;
+}

--- a/include/evhtp/evhtp.h
+++ b/include/evhtp/evhtp.h
@@ -1155,8 +1155,8 @@ EVHTP_EXPORT int evhtp_unescape_string(unsigned char ** out, unsigned char * str
  *
  * @param key a null terminated string
  * @param val a null terminated string
- * @param kalloc if 1, key will be copied, otherwise no copy performed
- * @param valloc if 1, val will be copied, otehrwise no copy performed
+ * @param kalloc if 1, key will be copied, if 0 no copy performed
+ * @param valloc if 1, val will be copied, if 0 no copy performed
  *
  * @return evhtp_header_t * or NULL on error
  */


### PR DESCRIPTION
## Minor
* anything that was returning a numerical value (i.e., 500) now uses the proper `EVHTP_RES_XX` definition.
* Lowered the span of lines for alignment. That was just getting insane.
* continued lines for a function call are aligned 4 spaces in, not at the open bracket.
* Added various debug logs / error logs statements.

## Bug Fixes
* Fixes #90, which I don't know if it was really a bug, just a misuse. When freeing key/value's, when you allocate one, `0` means do not allocate a copy, `1` means create a copy of the data, but the free function only checks for non zero values. The fix was to simply check for specifically '1' to determine if it is free'able.
**note** we may want to turn this into a boolean.

## Enhancements
* Added new function `htp__serv_setsockopts_` which makes sure all the proper listener sockopts are done in the proper order before bind/listen.
* Added `examples/example_basic.c` to show very basic usage (replacing test_basic).
* Added (disabled from the compilation for now) `examples/example_locality.c` which shows how to achieve CPU socket locality using the thread API's initialization, SO_REUSEPORT and a BPF socket filter to make sure that your RX CPU always matches the RX CPU. That's `SO_REUSEPORT` with no lock contention.