### PR TITLE
[#95] Fixes ignored return for s_body_read in parser.c

### DIFF
--- a/examples/example_basic.c
+++ b/examples/example_basic.c
@@ -38,7 +38,7 @@ main(int argc, char ** argv)
     evhtp_use_threads_wexit(htp, NULL, NULL, 4, NULL);
 #endif
 
-    log_info("Basic server, run: curl https://127.0.0.1:%d/",
+    log_info("Basic server, run: curl http://127.0.0.1:%d/",
             bind__sock_port0_(htp));
     event_base_loop(evbase, 0);
     return 0;

--- a/parser.c
+++ b/parser.c
@@ -2188,16 +2188,19 @@ hdrline_start:
                     const char * pe      = (const char *)(data + len);
                     size_t       to_read = _MIN_READ(pe - pp, p->content_len);
 
-                    if (to_read > 0)
-                    {
+                    if (to_read > 0) {
                         res = hook_body_run(p, hooks, pp, to_read);
 
                         i  += to_read - 1;
                         p->content_len -= to_read;
                     }
 
-                    if (p->content_len == 0)
-                    {
+                    if (res) {
+                        p->error = htparse_error_user;
+                        return i + 1;
+                    }
+
+                    if (p->content_len == 0) {
                         res      = hook_on_msg_complete_run(p, hooks);
                         p->state = s_start;
                     }


### PR DESCRIPTION
As the issue states, the user result of `hook_body_run` is not checked for error before checking `content_len`. This fixes that.