### PR TITLE
[#93] make on_conn_error and on_error hooks unique

### DIFF
--- a/include/evhtp/evhtp.h
+++ b/include/evhtp/evhtp.h
@@ -201,6 +201,7 @@ typedef void * (* evhtp_ssl_scache_init)(evhtp_t *);
 #define EVHTP_RES_FATAL         2
 #define EVHTP_RES_USER          3
 #define EVHTP_RES_DATA_TOO_LONG 4
+#define EVHTP_RES_PARSER_ERROR  5
 #define EVHTP_RES_OK            200
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS


### PR DESCRIPTION
The functions htp_hook_error_() is only called for request-ish errors
while htp_hook_connection_error_() is only called for connection-ish
errors.

This mainly applies to the following functions:

`htp__connection_readcb_` :
    if `EVHTP_RES_DATA_TOO_LONG` is the connection request return value,
    both `hook_error_()` and `hook_connection_error()` are called.

    if there is a parser error, `hook_connection_error_()` is called
    with the error type of `EVHTP_RES_PARSER_ERROR`

    `evbuffer_drain` is now called before the connection request status
    switch/case statement, and `EVHTP_RES_PAUSE` is now a case (moved)

`htp__connection_eventcb_`
    !!!!! PLEASE MAKE NOTE OF THIS CHANGE !!!!!
    this function now calls `htp__hook_connection_error_()` but no
    longer calls `htp__hook_request_error_()` to match the naming
    scheme.

    prior to this, both request_error and connection_error was called
    within this function.