### PR TITLE
[unescape_string] allow out to report unescaped length

### DIFF
--- a/evhtp.c
+++ b/evhtp.c
@@ -3428,6 +3428,7 @@ evhtp_unescape_string(unsigned char ** out, unsigned char * str, size_t str_len)
         } /* switch */
     }
 
+    *out = optr;
     return 0;
 }         /* evhtp_unescape_string */
 


### PR DESCRIPTION
Without having a way to report the length of the unescaped string, there is
no way to unescape a blob that contains nul.  This change modifies out to be
one character past the end of the unescaped string, allowing for

	unsigned char * escaped = ...;
	size_t escaped_l = strlen(escaped);
	unsigned char * unescaped[escaped_l+1];
	size_t unescaped_l = 0;
	unsigned char * c = unescaped;
	if (0==evhtp_unescape_string(&c, escaped, escaped_l))
		unescaped_l = c - unescaped;

It might be better to just return the unescaped length but some callers
might already rely on !evhtp_unescape_string indicating successful
unescaping.  If it turns out that more callers already rely on out not
changing, that's a better solution but it might be wise to just add a v2
function and have the original call it instead.

Signed-off-by: derrick@pallas.us