### PR TITLE
Fix compilation without deprecated OpenSSL 1.1 APIs

### DIFF
--- a/evhtp.c
+++ b/evhtp.c
@@ -2827,6 +2827,7 @@ htp__accept_cb_(struct evconnlistener * serv, int fd, struct sockaddr * s, int s
 
 #ifndef EVHTP_DISABLE_SSL
 #ifndef EVHTP_DISABLE_EVTHR
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
 void
@@ -2853,6 +2854,8 @@ htp__ssl_get_thread_id_(
     CRYPTO_THREADID_set_numeric(id, tid);
 #else
     return tid;
+#endif
+
 #endif
 }
 
@@ -4692,6 +4695,7 @@ evhtp_set_post_accept_cb(evhtp_t * htp, evhtp_post_accept_cb cb, void * arg)
 
 #ifndef EVHTP_DISABLE_SSL
 #ifndef EVHTP_DISABLE_EVTHR
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 int
 evhtp_ssl_use_threads(void)
 {
@@ -4724,6 +4728,7 @@ evhtp_ssl_use_threads(void)
     return 0;
 }
 
+#endif
 #endif
 
 int

--- a/evhtp.c
+++ b/evhtp.c
@@ -2828,36 +2828,28 @@ htp__accept_cb_(struct evconnlistener * serv, int fd, struct sockaddr * s, int s
 #ifndef EVHTP_DISABLE_SSL
 #ifndef EVHTP_DISABLE_EVTHR
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-static
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-void
-#else
-unsigned long
-#endif
-htp__ssl_get_thread_id_(
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-    CRYPTO_THREADID * id
-#else
-    void
-#endif
-    )
-{
-    unsigned long tid;
 
 #ifndef WIN32
-    tid = (unsigned long)pthread_self();
+#define tid (unsigned long)pthread_self()
 #else
-    tid = pthread_self().p;
+#define tid pthread_self().p
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-    CRYPTO_THREADID_set_numeric(id, tid);
-#else
-    return tid;
-#endif
-
-#endif
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
+static unsigned long
+htp__ssl_get_thread_id_(void)
+{
+	return tid;
 }
+#else
+static void
+htp__ssl_get_thread_id_(CRYPTO_THREADID *id)
+{
+	CRYPTO_THREADID_set_numeric(id, tid);
+}
+#endif
+
+#endif
 
 static void
 htp__ssl_thread_lock_(int mode, int type, const char * file, int line)

--- a/include/evhtp/evhtp.h
+++ b/include/evhtp/evhtp.h
@@ -26,6 +26,7 @@
 
 #ifndef EVHTP_DISABLE_SSL
 #include <event2/bufferevent_ssl.h>
+#include <openssl/dh.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>

--- a/sslutils.c
+++ b/sslutils.c
@@ -10,6 +10,11 @@
 #include "evhtp/sslutils.h"
 #include "internal.h"
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define X509_get0_notBefore X509_get_notBefore
+#define X509_get0_notAfter X509_get_notAfter
+#endif
+
 unsigned char *
 htp_sslutil_subject_tostr(evhtp_ssl_t * ssl) {
     unsigned char * subj_str;
@@ -78,11 +83,11 @@ htp_sslutil_issuer_tostr(evhtp_ssl_t * ssl) {
 
 unsigned char *
 htp_sslutil_notbefore_tostr(evhtp_ssl_t * ssl) {
-    BIO           * bio;
-    X509          * cert;
-    ASN1_TIME     * time;
-    size_t          len;
-    unsigned char * time_str;
+    BIO             * bio;
+    X509            * cert;
+    const ASN1_TIME * time;
+    size_t            len;
+    unsigned char   * time_str;
 
     if (!ssl) {
         return NULL;
@@ -92,7 +97,7 @@ htp_sslutil_notbefore_tostr(evhtp_ssl_t * ssl) {
         return NULL;
     }
 
-    if (!(time = X509_get_notBefore(cert))) {
+    if (!(time = X509_get0_notBefore(cert))) {
         X509_free(cert);
         return NULL;
     }
@@ -128,11 +133,11 @@ htp_sslutil_notbefore_tostr(evhtp_ssl_t * ssl) {
 
 unsigned char *
 htp_sslutil_notafter_tostr(evhtp_ssl_t * ssl) {
-    BIO           * bio;
-    X509          * cert;
-    ASN1_TIME     * time;
-    size_t          len;
-    unsigned char * time_str;
+    BIO             * bio;
+    X509            * cert;
+    const ASN1_TIME * time;
+    size_t            len;
+    unsigned char   * time_str;
 
     if (!ssl) {
         return NULL;
@@ -142,7 +147,7 @@ htp_sslutil_notafter_tostr(evhtp_ssl_t * ssl) {
         return NULL;
     }
 
-    if (!(time = X509_get_notAfter(cert))) {
+    if (!(time = X509_get0_notAfter(cert))) {
         X509_free(cert);
         return NULL;
     }


### PR DESCRIPTION
All threading APIs are gone with 1.1.

dh.h header does not get included with ssl.h automatically when deprecated
APIs are disabled.

X509_getBefore/After were replaced with get0 and getm variants. Switched
to the former as it can be const.